### PR TITLE
Pau

### DIFF
--- a/src/sharepoint/services/spfolder.js
+++ b/src/sharepoint/services/spfolder.js
@@ -314,7 +314,7 @@ angular.module('ngSharePoint').factory('SPFolder',
 
 			var self = this;
 			var def = $q.defer();
-			var folderPath = self.ServerRelativeUrl.rtrim('/') + '/' + folderName;
+			var folderPath = (self.ServerRelativeUrl || '').rtrim('/') + '/' + folderName;
 			var url = self.apiUrl + '/folders';
 
 			var headers = {


### PR DESCRIPTION
When a new root SPFolder is instantiated (without any path), addFolder
crash because can’t construct new folder path correctly.